### PR TITLE
TASK-40739 Disable Max length rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,11 +22,6 @@ module.exports = {
     'eslint:recommended',
   ],
   rules: {
-    'max-len': ['error', {
-      code: 80,
-      tabWidth: 2,
-      ignoreUrls: true
-    }],
     'indent': [
       'error', 2
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-meedsio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ESLint Contfiguration for Meeds.io based applications",
   "author": "eXo",
   "license": "LGPL-3.0-or-later",


### PR DESCRIPTION
The rule max-len isn't smart enough to distinguish when really we can exceed or not the maximum allowed length of a line.
Thus, here we will disable it.