### PR TITLE
Propose rule to exclude dependency axios.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = {
     'no-process-env': ['error'],
     'no-process-exit': ['error'],
     'no-proto': ['error'],
+    'no-restricted-imports': ['warn', 'axios'],
     'no-self-compare': ['error'],
     'no-sequences': ['error'],
     'no-shadow-restricted-names': ['error'],

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
     'no-process-env': ['error'],
     'no-process-exit': ['error'],
     'no-proto': ['error'],
-    'no-restricted-imports': ['warn', 'axios'],
+    'no-restricted-imports': ['error', 'axios'],
     'no-self-compare': ['error'],
     'no-sequences': ['error'],
     'no-shadow-restricted-names': ['error'],


### PR DESCRIPTION
For the moment it is only a warn, as some modules still use it. When this dependency is removed, we can put this rule as error